### PR TITLE
Update installation instructions for "cake"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tools
 
 dag_capture
 -----------
-A fast in memory capture program for use with Endace DAG cards. 
+A fast in memory capture program for use with Endace DAG cards.
 
 
 dag_anaylse
@@ -17,7 +17,7 @@ Reads the ERF encoded output of the dag_capture progam and coverts to ASCII
 
 dag_join
 --------
-Takes two ERF encoded files and looks for matching packets to join. Calculates the latency. 
+Takes two ERF encoded files and looks for matching packets to join. Calculates the latency.
 
 
 packet_gen
@@ -26,7 +26,7 @@ A full featured packet generator based on Netmap for use with Intel X520 NICs or
 
 camio_perf
 ----------
-A simple packet generator of the style of iperf. Uses sockets to generate high rate packets and has a precise pacing option. 
+A simple packet generator of the style of iperf. Uses sockets to generate high rate packets and has a precise pacing option.
 
 
 Requirements
@@ -34,16 +34,22 @@ Requirements
 
 Cake
 -----
-To build it, you must have the "cake" build system installed. 
+To build it, you must have the "cake" build system installed.
 You can obtain cake from https://github.com/Zomojo/Cake
-To insall cake, follow the instructions in "INSTALL".
+
+Use the cake-3.0.856-1 version of the "cake" build system (https://github.com/Zomojo/compiletools/releases/tag/cake-3.0.856-1). Other versions might work as well but are not tested.
+
+To download and install cake version 3.0.856-1: *sudo may be required when copying files*
+  1. `wget https://github.com/Zomojo/compiletools/archive/cake-3.0.856-1.tar.gz`
+  2. `tar -xvzf cake-3.0.856-1.tar.gz`
+  3. `cd compiletools-cake-3.0.856-1`
+  4. Copy the appropriate configuration file based on your distribution. For Ubuntu 14.04: `cp etc.cake.ubuntu.14.04 /etc/cake.conf`
+  5. `cp cake /usr/bin/cake`
+
+*Similar instructions can be found in the "INSTALL" file in the "cake" project directory, but they are slightly changed here.*
 
 CamIO 1.0
 ---------
-You can obtain the camio 1.0 library from 
+You can obtain the camio 1.0 library from
 https://github.com/mgrosvenor/camio1.0
 To build camio, run "build.sh" in the root directory.
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -52,4 +52,9 @@ CamIO 1.0
 ---------
 You can obtain the camio 1.0 library from
 https://github.com/mgrosvenor/camio1.0
+
 To build camio, run "build.sh" in the root directory.
+
+OpenSSL headers
+---------------
+The `dag_analyse` tool requires the OpenSSL headers to be installed: `sudo apt-get install openssl-dev`

--- a/dag_analyse/README.md
+++ b/dag_analyse/README.md
@@ -7,12 +7,12 @@ Requirements
 
 OpenSSL
 -------
-This software requires the openssl headers. On Ubuntu these can be installed with 
-sudo apt-get install openssl-dev
+This software requires the openssl headers. On Ubuntu these can be installed with: 
+`sudo apt-get install openssl-dev`
 
 Cake
 -----
-To build it, you must have the "cake" build system installed. 
+To build it, you must have the "cake" build system installed.
 You can obtain cake from https://github.com/Zomojo/Cake
 To insall cake, follow the instructions in "INSTALL".
 
@@ -46,9 +46,6 @@ dag_analyse:
 |Optional | -l  | --dag0-len    |    - The length (in records) to display from dag0. (-1 == all)  |
 |Optional | -p  | --packet-type |    - Filter by packets with the given type. 1=tcp, 2=udp, 3=icmp, -1 == all  |
 |Flag     | -H  | --write-header|    - Write a header describing each file's columns  |
-|Flag     | -c  | --use-csv     |    - Write the output in CSV format (default = False) | 
+|Flag     | -c  | --use-csv     |    - Write the output in CSV format (default = False) |
 |Flag     | -b  | --use-bin     |    - Write the output in bin format (default = False)  |
 |Flag     | -h  | --help        |    - Print this help message  |
-  
-
-


### PR DESCRIPTION
The repository has not been updated the last year, while the "cake" installation system has been changed a lot. I used an earlier version of "cake" to build the system and I provide the instructions here, in case someone needs them. It might be possible to compile with a newer version of the "cake" as well, but I didn't try it.